### PR TITLE
Add Cleaner to find orphaned ConfigMaps

### DIFF
--- a/examples/configmaps/orphaned_configmaps.yaml
+++ b/examples/configmaps/orphaned_configmaps.yaml
@@ -1,0 +1,120 @@
+# This Cleaner instance finds all ConfigMaps instances in
+# the namespace *bar* which are orphaned. Orphaned here means a ConfigMap that is not used by:
+# - Pod through volumes (pod.spec.volumes)
+# - Pod through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: completed-pods
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - namespace: bar
+      kind: Pod
+      group: ""
+      version: v1
+    - namespace: bar
+      kind: ConfigMap
+      group: ""
+      version: v1   
+    action: Delete
+    aggregatedSelection: |
+      function configMapsUsedByPods(pods)
+        local podConfigMaps = {}
+
+        for _, pod in ipairs(pods) do
+          if pod.spec.containers ~= nil then
+            for _, container in ipairs(pod.spec.containers) do
+              
+              if container.env ~= nil then
+                for _, env in ipairs(container.env) do
+                  if env.valueFrom ~= nil and env.valueFrom.configMapKeyRef ~= nil then
+                    podConfigMaps[env.valueFrom.configMapKeyRef.name] = true
+                  end
+                end
+              end
+
+              if container.envFrom ~= nil then
+                for _, envFrom in ipairs(container.envFrom) do
+                  if envFrom.configMapRef ~= nil then
+                    podConfigMaps[envFrom.configMapRef.name] = true
+                  end
+                end
+              end  
+            end
+          end
+
+          if pod.spec.initContainers ~= nil then
+            for _, initContainer in ipairs(pod.spec.initContainers) do
+
+              if initContainer.env ~= nil then
+                for _, env in ipairs(initContainer.env) do
+                  if env.valueFrom ~= nil and env.valueFrom.configMapKeyRef ~= nil then
+                    podConfigMaps[env.valueFrom.configMapKeyRef.name] = true
+                  end
+                end
+              end
+
+              if initContainer.envFrom ~= nil then
+                for _, envFrom in ipairs(initContainer.envFrom) do
+                  if envFrom.configMapRef ~= nil then
+                    podConfigMaps[envFrom.configMapRef.name] = true
+                  end
+                end
+              end  
+
+            end
+          end    
+
+          if pod.spec.volumes ~= nil then  
+            for _, volume in ipairs(pod.spec.volumes) do
+              if volume.configMap ~= nil then
+                podConfigMaps[volume.configMap.name] = true
+              end
+
+              if volume.projected ~= nil and volume.projected.sources ~= nil then
+                for _, projectedResource in ipairs(volume.projected.sources) do
+                  if projectedResource.configMap ~= nil then
+                    podConfigMaps[projectedResource.configMap.name] = true
+                  end
+                end
+              end
+            end
+          end
+        end  
+
+        return podConfigMaps
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        local pods = {}
+        local configMaps = {}
+        local unusedConfigMaps = {}
+
+        -- Separate configMaps and podsfrom the resources
+        for _, resource in ipairs(resources) do
+            local kind = resource.kind
+            if kind == "ConfigMap" then
+              table.insert(configMaps, resource)
+            elseif kind == "Pod" then
+              table.insert(pods, resource)
+            end
+        end
+
+        podConfigMaps = configMapsUsedByPods(pods)
+
+        for _, configMap in ipairs(configMaps) do
+          if not podConfigMaps[configMap.metadata.name] then
+            table.insert(unusedConfigMaps, configMap)
+          end
+        end
+
+        hs.resources = unusedConfigMaps
+        return hs
+      end

--- a/examples/secrets/orphaned_secrets.yaml
+++ b/examples/secrets/orphaned_secrets.yaml
@@ -1,10 +1,10 @@
 # This Cleaner instance finds all Secret instances in
-# the namespace *bar* which are orphaned. Orphaned here means Secret is not used by:
-# - Secrets used through volumes (pod.spec.volumes)
-# - Secrets used through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
-# - Secrets used for image pulls (pod.spec.imagePullSecrets)
-# - Secrets used by Ingress TLS (ingress.spec.tls)
-# - Secrets used by ServiceAccounts
+# the namespace *bar* which are orphaned. Orphaned here means a Secret that is not used by:
+# - Pod through volumes (pod.spec.volumes)
+# - Pod through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
+# - Pod for image pulls (pod.spec.imagePullSecrets)
+# - Ingress TLS (ingress.spec.tls)
+# - ServiceAccounts
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:
@@ -29,7 +29,7 @@ spec:
     action: Delete
     aggregatedSelection: |
       function secretsUsedByPods(pods)
-        local podSecrets = {}  -- Define podSecrets as a local variable
+        local podSecrets = {}
 
         for _, pod in ipairs(pods) do
           if pod.spec.containers ~= nil then
@@ -77,7 +77,7 @@ spec:
                 podSecrets[volume.secret.secretName] = true
               end
 
-              if volume.projected ~= nil then
+              if volume.projected ~= nil and volume.projected.sources ~= nil then
                 for _, projectedResource in ipairs(volume.projected.sources) do
                   if projectedResource.secret ~= nil then
                     podSecrets[projectedResource.secret.name] = true

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
@@ -1,0 +1,120 @@
+# This Cleaner instance finds all ConfigMaps instances in
+# the namespace *bar* which are orphaned. Orphaned here means a ConfigMap that is not used by:
+# - Pod through volumes (pod.spec.volumes)
+# - Pod through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: completed-pods
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - namespace: bar
+      kind: Pod
+      group: ""
+      version: v1
+    - namespace: bar
+      kind: ConfigMap
+      group: ""
+      version: v1   
+    action: Delete
+    aggregatedSelection: |
+      function configMapsUsedByPods(pods)
+        local podConfigMaps = {}
+
+        for _, pod in ipairs(pods) do
+          if pod.spec.containers ~= nil then
+            for _, container in ipairs(pod.spec.containers) do
+              
+              if container.env ~= nil then
+                for _, env in ipairs(container.env) do
+                  if env.valueFrom ~= nil and env.valueFrom.configMapKeyRef ~= nil then
+                    podConfigMaps[env.valueFrom.configMapKeyRef.name] = true
+                  end
+                end
+              end
+
+              if container.envFrom ~= nil then
+                for _, envFrom in ipairs(container.envFrom) do
+                  if envFrom.configMapRef ~= nil then
+                    podConfigMaps[envFrom.configMapRef.name] = true
+                  end
+                end
+              end  
+            end
+          end
+
+          if pod.spec.initContainers ~= nil then
+            for _, initContainer in ipairs(pod.spec.initContainers) do
+
+              if initContainer.env ~= nil then
+                for _, env in ipairs(initContainer.env) do
+                  if env.valueFrom ~= nil and env.valueFrom.configMapKeyRef ~= nil then
+                    podConfigMaps[env.valueFrom.configMapKeyRef.name] = true
+                  end
+                end
+              end
+
+              if initContainer.envFrom ~= nil then
+                for _, envFrom in ipairs(initContainer.envFrom) do
+                  if envFrom.configMapRef ~= nil then
+                    podConfigMaps[envFrom.configMapRef.name] = true
+                  end
+                end
+              end  
+
+            end
+          end    
+
+          if pod.spec.volumes ~= nil then  
+            for _, volume in ipairs(pod.spec.volumes) do
+              if volume.configMap ~= nil then
+                podConfigMaps[volume.configMap.name] = true
+              end
+
+              if volume.projected ~= nil and volume.projected.sources ~= nil then
+                for _, projectedResource in ipairs(volume.projected.sources) do
+                  if projectedResource.configMap ~= nil then
+                    podConfigMaps[projectedResource.configMap.name] = true
+                  end
+                end
+              end
+            end
+          end
+        end  
+
+        return podConfigMaps
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        local pods = {}
+        local configMaps = {}
+        local unusedConfigMaps = {}
+
+        -- Separate configMaps and podsfrom the resources
+        for _, resource in ipairs(resources) do
+            local kind = resource.kind
+            if kind == "ConfigMap" then
+              table.insert(configMaps, resource)
+            elseif kind == "Pod" then
+              table.insert(pods, resource)
+            end
+        end
+
+        podConfigMaps = configMapsUsedByPods(pods)
+
+        for _, configMap in ipairs(configMaps) do
+          if not podConfigMaps[configMap.metadata.name] then
+            table.insert(unusedConfigMaps, configMap)
+          end
+        end
+
+        hs.resources = unusedConfigMaps
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/matching.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: matching
+data:
+  SPECIAL_LEVEL: very
+  SPECIAL_TYPE: charm

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/resources.yaml
@@ -1,0 +1,83 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-env
+data:
+  special.how: very
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-env
+spec:
+  containers:
+    - name: test-container
+      image: registry.k8s.io/busybox
+      command: [ "/bin/sh", "-c", "env" ]
+      env:
+        # Define the environment variable
+        - name: SPECIAL_LEVEL_KEY
+          valueFrom:
+            configMapKeyRef:
+              # The ConfigMap containing the value you want to assign to SPECIAL_LEVEL_KEY
+              name: config-env
+              # Specify the key associated with the value
+              key: special.how
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-envfrom
+data:
+  SPECIAL_LEVEL: very
+  SPECIAL_TYPE: charm
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-envfrom
+spec:
+  containers:
+    - name: test-container
+      image: registry.k8s.io/busybox
+      command: [ "/bin/sh", "-c", "env" ]
+      envFrom:
+      - configMapRef:
+          name: config-envfrom
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-volume
+data:
+  SPECIAL_LEVEL: very
+  SPECIAL_TYPE: charm
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-test-pod
+spec:
+  containers:
+    - name: test-container
+      image: registry.k8s.io/busybox
+      command: [ "/bin/sh", "-c", "ls /etc/config/" ]
+      volumeMounts:
+      - name: config-volume
+        mountPath: /etc/config
+  volumes:
+    - name: config-volume
+      configMap:
+        # Provide the name of the ConfigMap containing the files you want
+        # to add to the container
+        name: config-volume
+  restartPolicy: Never
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: matching
+data:
+  SPECIAL_LEVEL: very
+  SPECIAL_TYPE: charm

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
@@ -1,10 +1,10 @@
 # This Cleaner instance finds all Secret instances in
-# the namespace *bar* which are orphaned. Orphaned here means Secret is not used by:
-# - Secrets used through volumes (pod.spec.volumes)
-# - Secrets used through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
-# - Secrets used for image pulls (pod.spec.imagePullSecrets)
-# - Secrets used by Ingress TLS (ingress.spec.tls)
-# - Secrets used by ServiceAccounts
+# the namespace *bar* which are orphaned. Orphaned here means a Secret that is not used by:
+# - Pod through volumes (pod.spec.volumes)
+# - Pod through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)
+# - Pod for image pulls (pod.spec.imagePullSecrets)
+# - Ingress TLS (ingress.spec.tls)
+# - ServiceAccounts
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:
@@ -29,7 +29,7 @@ spec:
     action: Delete
     aggregatedSelection: |
       function secretsUsedByPods(pods)
-        local podSecrets = {}  -- Define podSecrets as a local variable
+        local podSecrets = {}
 
         for _, pod in ipairs(pods) do
           if pod.spec.containers ~= nil then
@@ -77,7 +77,7 @@ spec:
                 podSecrets[volume.secret.secretName] = true
               end
 
-              if volume.projected ~= nil then
+              if volume.projected ~= nil and volume.projected.sources ~= nil then
                 for _, projectedResource in ipairs(volume.projected.sources) do
                   if projectedResource.secret ~= nil then
                     podSecrets[projectedResource.secret.name] = true


### PR DESCRIPTION
An orphaned ConfigMap is a ConfigMap that is not used by:
- Pod through volumes (pod.spec.volumes)
- Pod through environment variables (pod.spec.containers.env and pod.spec.containers.envFrom)