### PR TITLE
More examples

### DIFF
--- a/examples/deployments/deployment_with_no_autoscaler.yaml
+++ b/examples/deployments/deployment_with_no_autoscaler.yaml
@@ -4,14 +4,14 @@
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:
-  name: cleaner-sample3
+  name: deployment-with-no-autoscaler
 spec:
   schedule: "* 0 * * *"
   resourcePolicySet:
     resourceSelectors:
     - namespace: foo
       kind: Deployment
-      group: ""
+      group: "apps"
       version: v1
     - namespace: foo
       kind: HorizontalPodAutoscaler

--- a/examples/deployments/deployment_with_replica_zero.yaml
+++ b/examples/deployments/deployment_with_replica_zero.yaml
@@ -1,0 +1,23 @@
+# This Cleaner instance will find any deployment in any namespace
+# with spec.replicas set to 0 and deletes those instances
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: deployment-with-zero-replicas
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Deployment
+      group: "apps"
+      version: v1
+      evaluate: |
+        function evaluate()
+          hs = {}
+          hs.matching = false
+          if obj.spec.replicas == 0 then
+            hs.matching = true
+          end
+          return hs
+        end
+    action: Delete

--- a/examples/persistent-volume-claims/cleaner.yaml
+++ b/examples/persistent-volume-claims/cleaner.yaml
@@ -1,0 +1,72 @@
+# Find all PersistentVolumeClaims currently not
+# used by any Pods. It considers all namespaces.
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: stale-persistent-volume-claim
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pods
+      group: ""
+      version: v1
+    - kind: PersistentVolumeClaim
+      group: ""
+      version: v1
+    action: Delete # Delete matching resources
+    aggregatedSelection: |
+      function isUsed(pvc, pods)
+        if pods == nil then
+          return false
+        end
+        for _, pod in ipairs(pods) do
+          if pod.spec.volumes ~= nil then
+            for _,volume in ipairs(pod.spec.volumes) do
+              if volume.persistentVolumeClaim.claimName == pvc.metadata.name then
+                return true
+              end
+            end
+          end
+        end
+        return false
+      end  
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        local pods = {}
+        local pvcs = {}
+        local unusedPVCs = {}
+
+        -- Separate pods and pvcs from the resources
+        -- Group those by namespace
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Pod" then
+            if not pods[resource.metadata.namespace] then
+              pods[resource.metadata.namespace] = {}
+            end
+            table.insert(pods[resource.metadata.namespace], resource)
+          elseif kind == "PersistentVolumeClaim" then
+            if not pvcs[resource.metadata.namespace] then
+              pvcs[resource.metadata.namespace] = {}
+            end
+            table.insert(pvcs[resource.metadata.namespace], resource)
+          end
+        end
+
+        -- Iterate through each namespace and identify unused PVCs
+        for namespace, perNamespacePVCs in pairs(pvcs) do
+          for _, pvc in ipairs(perNamespacePVCs) do
+            if not isUsed(pvc, pods[namespace]) then
+              table.insert(unusedPVCs, pvc)
+            end
+          end
+        end
+        
+        hs.resources = unusedPVCs
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/deployment_with_autoscaler/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/deployment_with_autoscaler/cleaner.yaml
@@ -2,14 +2,14 @@
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:
-  name: cleaner-sample3
+  name: deployment-with-no-autoscaler
 spec:
   schedule: "* 0 * * *"
   resourcePolicySet:
     resourceSelectors:
     - namespace: foo
       kind: Deployment
-      group: ""
+      group: "apps"
       version: v1
     - namespace: foo
       kind: HorizontalPodAutoscaler

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/cleaner.yaml
@@ -1,0 +1,72 @@
+# Find all PersistentVolumeClaims currently not
+# used by any Pods. It considers all namespaces.
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: stale-persistent-volume-claim
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pods
+      group: ""
+      version: v1
+    - kind: PersistentVolumeClaim
+      group: ""
+      version: v1
+    action: Delete # Delete matching resources
+    aggregatedSelection: |
+      function isUsed(pvc, pods)
+        if pods == nil then
+          return false
+        end
+        for _, pod in ipairs(pods) do
+          if pod.spec.volumes ~= nil then
+            for _,volume in ipairs(pod.spec.volumes) do
+              if volume.persistentVolumeClaim.claimName == pvc.metadata.name then
+                return true
+              end
+            end
+          end
+        end
+        return false
+      end  
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        local pods = {}
+        local pvcs = {}
+        local unusedPVCs = {}
+
+        -- Separate pods and pvcs from the resources
+        -- Group those by namespace
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Pod" then
+            if not pods[resource.metadata.namespace] then
+              pods[resource.metadata.namespace] = {}
+            end
+            table.insert(pods[resource.metadata.namespace], resource)
+          elseif kind == "PersistentVolumeClaim" then
+            if not pvcs[resource.metadata.namespace] then
+              pvcs[resource.metadata.namespace] = {}
+            end
+            table.insert(pvcs[resource.metadata.namespace], resource)
+          end
+        end
+
+        -- Iterate through each namespace and identify unused PVCs
+        for namespace, perNamespacePVCs in pairs(pvcs) do
+          for _, pvc in ipairs(perNamespacePVCs) do
+            if not isUsed(pvc, pods[namespace]) then
+              table.insert(unusedPVCs, pvc)
+            end
+          end
+        end
+        
+        hs.resources = unusedPVCs
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/matching.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unused
+  namespace: bar
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi   

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/resources.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: used
+  namespace: foo
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: task-pv-pod
+  namespace: foo
+spec:
+  volumes:
+    - name: task-pv-storage
+      persistentVolumeClaim:
+        claimName: used
+  containers:
+    - name: task-pv-container
+      image: nginx
+      ports:
+        - containerPort: 80
+          name: "http-server"
+      volumeMounts:
+        - mountPath: "/usr/share/nginx/html"
+          name: task-pv-storage
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: unused
+  namespace: bar
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi          

--- a/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/cleaner.yaml
+++ b/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/cleaner.yaml
@@ -1,0 +1,23 @@
+# This Cleaner instance will find any deployment in any namespace
+# with spec.replicas set to 0 and deletes those instances
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: deployment-with-zero-replicas
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Deployment
+      group: ""
+      version: v1
+      evaluate: |
+        function evaluate()
+          hs = {}
+          hs.matching = false
+          if obj.spec.replicas == 0 then
+            hs.matching = true
+          end
+          return hs
+        end
+    action: Delete

--- a/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/matching.yaml
+++ b/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/matching.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: zero-replicas
+spec:
+  replicas: 0
+  template:
+    metadata:
+      labels:
+        app: php-apache
+    spec:
+      containers:
+        - name: php-apache
+          image: php:8.0-apache
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/non-matching.yaml
+++ b/internal/controller/executor/validate_resourceselector/deployment_with_zero_replicas/non-matching.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: zero-replicas
+spec:
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        app: php-apache
+    spec:
+      containers:
+        - name: php-apache
+          image: php:8.0-apache
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi


### PR DESCRIPTION
- Cleaner to identify stale deployments. Stale deployments are instances with spec.replicas set to 0
- Cleaner to identify orphaned persistentVolumeClaim. An orphaned PersistentVolumeClaim is an instance that is not referenced by any pod