### PR TITLE
Add Cleaner instances for unused Roles and ClusterRoles

### DIFF
--- a/examples/clusterroles/cleaner.yaml
+++ b/examples/clusterroles/cleaner.yaml
@@ -1,0 +1,62 @@
+# This Cleaner instance finds all unused ClusterRole instances.
+# An unused ClusterRole is an instance that is not referenced
+# by any ClusterRoleBinding or RoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-roles
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: ClusterRole
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: ClusterRoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1      
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        -- Contains list of existing ClusterRoles
+        local existingClusterRoles = {}
+        -- Contains list of ClusterRoles currently referenced by
+        -- roleBindings or ClusterRoleBindings
+        local usedClusterRoles = {}
+
+        local unusedClusterRoles = {}
+
+        -- Create list of existingClusterRoles and usedClusterRoles
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "ClusterRole" then
+            table.insert(existingClusterRoles, resource)
+          elseif kind == "ClusterRoleBinding" then
+            if resource.roleRef.kind == "ClusterRole" then
+              usedClusterRoles[resource.roleRef.name] = true
+            end
+          elseif kind == "RoleBinding" then
+            if resource.roleRef.kind == "ClusterRole" then
+              usedClusterRoles[resource.roleRef.name] = true
+            end
+          end
+        end
+
+        -- Iterate over existing clusterRoles and find not used anymore
+        for _,clusterRole in ipairs(existingClusterRoles) do
+          if not usedClusterRoles[clusterRole.metadata.name] then
+            table.insert(unusedClusterRoles, clusterRole)
+          end
+        end
+        
+        hs.resources = unusedClusterRoles
+        return hs
+      end

--- a/examples/roles/cleaner.yaml
+++ b/examples/roles/cleaner.yaml
@@ -1,0 +1,62 @@
+# This Cleaner instance finds all unused Role instances.
+# All namespaces are considered.
+# An unused Role is an instance that is not referenced
+# by any RoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-roles
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Role
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      -- Given Role namespace and name returns a unique Key
+      function getRoleKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        -- Contains list of existing roles
+        local existingRoles = {}
+        -- Contains list of roles currently referenced by roleBindings
+        local usedRoles = {}
+
+        local unusedRoles = {}
+
+        -- Create list of existingRoles and usedRoles
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Role" then
+            table.insert(existingRoles, resource)
+          elseif kind == "RoleBinding" then
+            if resource.roleRef.kind == "Role" then
+              roleKey = getRoleKey(resource.metadata.namespace, resource.roleRef.name)
+              usedRoles[roleKey] = true
+            end
+          end
+        end
+
+        -- Iterate over existing roles and find not used anymore
+        for _,role in ipairs(existingRoles) do
+          roleKey = getRoleKey(role.metadata.namespace, role.metadata.name)
+          if not usedRoles[roleKey] then
+            table.insert(unusedRoles, role)
+          end
+        end
+        
+        hs.resources = unusedRoles
+        return hs
+      end

--- a/examples/secrets/orphaned_secrets.yaml
+++ b/examples/secrets/orphaned_secrets.yaml
@@ -92,17 +92,16 @@ spec:
       end
 
       function secretsUsedByIngresses(ingresses)
-        local ingressSecret = {}
-
+        local ingressSecrets = {}
         for _, ingress in ipairs(ingresses) do
-          if ingress.tls ~= nil  then
-            for _, tls in ipairs(ingress.tls) do
+          if ingress.spec.tls ~= nil  then
+            for _, tls in ipairs(ingress.spec.tls) do
               ingressSecrets[tls.secretName] = true
             end
           end
         end
         
-        return ingressSecret
+        return ingressSecrets
       end
 
       function evaluate()

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
@@ -92,17 +92,16 @@ spec:
       end
 
       function secretsUsedByIngresses(ingresses)
-        local ingressSecret = {}
-
+        local ingressSecrets = {}
         for _, ingress in ipairs(ingresses) do
-          if ingress.tls ~= nil  then
-            for _, tls in ipairs(ingress.tls) do
+          if ingress.spec.tls ~= nil  then
+            for _, tls in ipairs(ingress.spec.tls) do
               ingressSecrets[tls.secretName] = true
             end
           end
         end
         
-        return ingressSecret
+        return ingressSecrets
       end
 
       function evaluate()

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/resources.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secret-volume
       secret:
-        secretName: olume-secret
+        secretName: volume-secret
   containers:
     - name: dotfile-test-container
       image: registry.k8s.io/busybox

--- a/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/cleaner.yaml
@@ -1,0 +1,62 @@
+# This Cleaner instance finds all unused ClusterRole instances.
+# An unused ClusterRole is an instance that is not referenced
+# by any ClusterRoleBinding or RoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-roles
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: ClusterRole
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: ClusterRoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1      
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        -- Contains list of existing ClusterRoles
+        local existingClusterRoles = {}
+        -- Contains list of ClusterRoles currently referenced by
+        -- roleBindings or ClusterRoleBindings
+        local usedClusterRoles = {}
+
+        local unusedClusterRoles = {}
+
+        -- Create list of existingClusterRoles and usedClusterRoles
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "ClusterRole" then
+            table.insert(existingClusterRoles, resource)
+          elseif kind == "ClusterRoleBinding" then
+            if resource.roleRef.kind == "ClusterRole" then
+              usedClusterRoles[resource.roleRef.name] = true
+            end
+          elseif kind == "RoleBinding" then
+            if resource.roleRef.kind == "ClusterRole" then
+              usedClusterRoles[resource.roleRef.name] = true
+            end
+          end
+        end
+
+        -- Iterate over existing clusterRoles and find not used anymore
+        for _,clusterRole in ipairs(existingClusterRoles) do
+          if not usedClusterRoles[clusterRole.metadata.name] then
+            table.insert(unusedClusterRoles, clusterRole)
+          end
+        end
+        
+        hs.resources = unusedClusterRoles
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/matching.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unused
+rules:
+- apiGroups: ["apps"]
+  resources: ["Deployments", "ReplicaSets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/resources.yaml
@@ -1,0 +1,53 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: used-by-clusterrolebinding
+rules:
+- apiGroups: ["*"]
+  resources: ["Pods"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: example-clusterbinding
+subjects:
+  - kind: ServiceAccount
+    name: example
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name:  used-by-clusterrolebinding
+  apiGroup: rbac.authorization.k8s.io 
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: used-by-rolebinding
+rules:
+- apiGroups: ["apps"]
+  resources: ["Deployments", "ReplicaSets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: example-rolebinding
+  namespace: default
+subjects:
+  - kind: ServiceAccount
+    name: example
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: used-by-rolebinding
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: unused
+rules:
+- apiGroups: ["apps"]
+  resources: ["Deployments", "ReplicaSets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/internal/controller/executor/validate_aggregatedselection/unused_roles/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_roles/cleaner.yaml
@@ -1,0 +1,62 @@
+# This Cleaner instance finds all unused Role instances.
+# All namespaces are considered.
+# An unused Role is an instance that is not referenced
+# by any RoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-roles
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Role
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      -- Given Role namespace and name returns a unique Key
+      function getRoleKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+
+        -- Contains list of existing roles
+        local existingRoles = {}
+        -- Contains list of roles currently referenced by roleBindings
+        local usedRoles = {}
+
+        local unusedRoles = {}
+
+        -- Create list of existingRoles and usedRoles
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Role" then
+            table.insert(existingRoles, resource)
+          elseif kind == "RoleBinding" then
+            if resource.roleRef.kind == "Role" then
+              roleKey = getRoleKey(resource.metadata.namespace, resource.roleRef.name)
+              usedRoles[roleKey] = true
+            end
+          end
+        end
+
+        -- Iterate over existing roles and find not used anymore
+        for _,role in ipairs(existingRoles) do
+          roleKey = getRoleKey(role.metadata.namespace, role.metadata.name)
+          if not usedRoles[roleKey] then
+            table.insert(unusedRoles, role)
+          end
+        end
+        
+        hs.resources = unusedRoles
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/unused_roles/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_roles/matching.yaml
@@ -1,0 +1,19 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: unused-role
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: unused-role2
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/internal/controller/executor/validate_aggregatedselection/unused_roles/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_roles/resources.yaml
@@ -1,0 +1,73 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default
+  name: used-role
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: default 
+  name: example-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: example
+    namespace: default
+roleRef:
+  kind: Role
+  name: used-role
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: bar
+  name: used-role
+rules:
+  - apiGroups: ["*"]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: bar 
+  name: example-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: example
+    namespace: bar
+roleRef:
+  kind: Role
+  name: used-role
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: unused-role
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  namespace: default
+  name: unused-role2
+rules:
+- apiGroups: [""] # "" indicates the core API group
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/internal/controller/executor/validate_test.go
+++ b/internal/controller/executor/validate_test.go
@@ -344,8 +344,25 @@ func getResources(dirName, fileName string) []*unstructured.Unstructured {
 	return resources
 }
 
+func getKey(u *unstructured.Unstructured) string {
+	return fmt.Sprintf("%s:%s/%s", u.GetKind(), u.GetNamespace(), u.GetName())
+}
+
 func verifyMatchingResources(result, matchingResources []*unstructured.Unstructured) {
+	// This is used to keep track of resources that are expected to match
+	expected := map[string]bool{}
+
 	for i := range matchingResources {
 		Expect(result).To(ContainElement(matchingResources[i]))
+		expected[getKey(matchingResources[i])] = true
+	}
+
+	// verify only expected matching objects are found
+	for i := range result {
+		key := getKey(result[i])
+		if ok := expected[key]; !ok {
+			// Print the resource that is not expected to be a match
+			Expect(key).To(BeEmpty())
+		}
 	}
 }


### PR DESCRIPTION
- A Role is unused if no RoleBinding instances reference it
- A ClusterRole is unused if no ClusterRoleBinding or RoleBinding instances reference it

Also enhanced validation test: only resources listed in matching.yaml are expected to be returned by __aggregatedSelection__