### PR TITLE
Add Cleaner instance to detect unused Ingress

### DIFF
--- a/examples/clusterroles/cleaner.yaml
+++ b/examples/clusterroles/cleaner.yaml
@@ -23,7 +23,6 @@ spec:
     aggregatedSelection: |
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         -- Contains list of existing ClusterRoles

--- a/examples/configmaps/orphaned_configmaps.yaml
+++ b/examples/configmaps/orphaned_configmaps.yaml
@@ -98,7 +98,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/examples/deployments/deployment_with_no_autoscaler.yaml
+++ b/examples/deployments/deployment_with_no_autoscaler.yaml
@@ -19,7 +19,6 @@ spec:
     aggregatedSelection: |
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local deployments = {}

--- a/examples/deployments/orphaned_deployment.yaml
+++ b/examples/deployments/orphaned_deployment.yaml
@@ -54,7 +54,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local deployments = {}

--- a/examples/ingresses/cleaner.yaml
+++ b/examples/ingresses/cleaner.yaml
@@ -1,0 +1,102 @@
+# Find all unused Ingress instances. 
+# An Ingress instance is considered unused if:
+# - default backend is not defined or not existings
+# - none of referenced services (via spec.rules) exists
+# 
+# This does not take into account resource (field Resource *v1.TypedLocalObjectReference)
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: stale-ingresses
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Ingress
+      group: "networking.k8s.io"
+      version: v1
+    - kind: Service
+      group: ""
+      version: v1
+    action: Delete # Delete matching resources
+    aggregatedSelection: |
+      function getKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      -- check default backend: if default backend is configured, return true
+      -- if currently exists
+      function isDefaultBackendValid(ingress, services)
+        if ingress.spec.defaultBackend ~= nil then
+          if ingress.spec.defaultBackend.service ~= nil then
+            key = getKey(ingress.metadata.namespace, ingress.spec.defaultBackend.service.name)
+            if services[key] then
+              return true
+            end
+          end
+        end
+        return false
+      end
+
+      -- check if any referenced service (via rules) currently exists
+      -- returns false only if none of the referenced services exists
+      function isAnyReferencedServiceValid(ingress, services)
+        if ingress.spec.rules ~= nil then
+          for _,rule in ipairs(ingress.spec.rules) do
+            if rule.http ~= nil and rule.http.paths ~= nil then
+              for _,path in ipairs(rule.http.paths) do
+                if path.backend.service ~= nil then
+                  key = getKey(ingress.metadata.namespace, path.backend.service.name)
+                  if services[key] then
+                    return true
+                  end
+                end
+              end
+            end
+          end
+        end 
+        return false
+      end
+
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+        
+        local services = {}
+        local ingresses = {}
+        local unusedIngresses = {}
+
+        -- Separate ingresses and services from the resources
+        -- Store existing services in a map like struct
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Ingress" then
+            table.insert(ingresses, resource)
+          elseif kind == "Service" then
+            key = getKey(resource.metadata.namespace,resource.metadata.name)
+            print(key)
+            services[key] = true
+          end
+        end
+
+        for _,ingress in ipairs(ingresses) do
+          local used = false
+          key = getKey(ingress.metadata.namespace, ingress.metadata.name)
+          if isDefaultBackendValid(ingress, services) then
+            used = true
+          elseif isAnyReferencedServiceValid(ingress, services) then
+            print("MGIANLUC ingress used by service")
+            used = true
+          end
+
+          if not used then
+            print("MGIANLUC ingress not used") 
+            table.insert(unusedIngresses, ingress)
+          end
+        end
+
+        hs.resources = unusedIngresses
+        return hs
+      end

--- a/examples/persistent-volume-claims/cleaner.yaml
+++ b/examples/persistent-volume-claims/cleaner.yaml
@@ -34,7 +34,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/examples/pod-disruption-budgets/cleaner.yaml
+++ b/examples/pod-disruption-budgets/cleaner.yaml
@@ -47,7 +47,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
       
         local pdbs= {}

--- a/examples/roles/cleaner.yaml
+++ b/examples/roles/cleaner.yaml
@@ -26,7 +26,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         -- Contains list of existing roles

--- a/examples/secrets/orphaned_secrets.yaml
+++ b/examples/secrets/orphaned_secrets.yaml
@@ -114,7 +114,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/internal/controller/executor/validate_aggregatedselection/deployment_with_autoscaler/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/deployment_with_autoscaler/cleaner.yaml
@@ -19,7 +19,6 @@ spec:
     aggregatedSelection: |
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local deployments = {}

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
@@ -98,7 +98,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_deployments/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_deployments/cleaner.yaml
@@ -54,7 +54,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local deployments = {}

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_persistent-volume-claims/cleaner.yaml
@@ -34,7 +34,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_secrets/cleaner.yaml
@@ -114,7 +114,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         local pods = {}

--- a/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_clusterrole.yaml/cleaner.yaml
@@ -23,7 +23,6 @@ spec:
     aggregatedSelection: |
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         -- Contains list of existing ClusterRoles

--- a/internal/controller/executor/validate_aggregatedselection/unused_ingresses/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_ingresses/cleaner.yaml
@@ -1,0 +1,102 @@
+# Find all unused Ingress instances. 
+# An Ingress instance is considered unused if:
+# - default backend is not defined or not existings
+# - none of referenced services (via spec.rules) exists
+# 
+# This does not take into account resource (field Resource *v1.TypedLocalObjectReference)
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: stale-ingresses
+spec:
+  schedule: "* 0 * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Ingress
+      group: "networking.k8s.io"
+      version: v1
+    - kind: Service
+      group: ""
+      version: v1
+    action: Delete # Delete matching resources
+    aggregatedSelection: |
+      function getKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      -- check default backend: if default backend is configured, return true
+      -- if currently exists
+      function isDefaultBackendValid(ingress, services)
+        if ingress.spec.defaultBackend ~= nil then
+          if ingress.spec.defaultBackend.service ~= nil then
+            key = getKey(ingress.metadata.namespace, ingress.spec.defaultBackend.service.name)
+            if services[key] then
+              return true
+            end
+          end
+        end
+        return false
+      end
+
+      -- check if any referenced service (via rules) currently exists
+      -- returns false only if none of the referenced services exists
+      function isAnyReferencedServiceValid(ingress, services)
+        if ingress.spec.rules ~= nil then
+          for _,rule in ipairs(ingress.spec.rules) do
+            if rule.http ~= nil and rule.http.paths ~= nil then
+              for _,path in ipairs(rule.http.paths) do
+                if path.backend.service ~= nil then
+                  key = getKey(ingress.metadata.namespace, path.backend.service.name)
+                  if services[key] then
+                    return true
+                  end
+                end
+              end
+            end
+          end
+        end 
+        return false
+      end
+
+
+      function evaluate()
+        local hs = {}
+        hs.valid = true
+        hs.message = ""
+        
+        local services = {}
+        local ingresses = {}
+        local unusedIngresses = {}
+
+        -- Separate ingresses and services from the resources
+        -- Store existing services in a map like struct
+        for _, resource in ipairs(resources) do
+          local kind = resource.kind
+          if kind == "Ingress" then
+            table.insert(ingresses, resource)
+          elseif kind == "Service" then
+            key = getKey(resource.metadata.namespace,resource.metadata.name)
+            print(key)
+            services[key] = true
+          end
+        end
+
+        for _,ingress in ipairs(ingresses) do
+          local used = false
+          key = getKey(ingress.metadata.namespace, ingress.metadata.name)
+          if isDefaultBackendValid(ingress, services) then
+            used = true
+          elseif isAnyReferencedServiceValid(ingress, services) then
+            print("MGIANLUC ingress used by service")
+            used = true
+          end
+
+          if not used then
+            print("MGIANLUC ingress not used") 
+            table.insert(unusedIngresses, ingress)
+          end
+        end
+
+        hs.resources = unusedIngresses
+        return hs
+      end

--- a/internal/controller/executor/validate_aggregatedselection/unused_ingresses/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_ingresses/matching.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-default-backend
+  namespace: foobar
+spec:
+  defaultBackend:
+    service:
+      name: default-backend

--- a/internal/controller/executor/validate_aggregatedselection/unused_ingresses/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_ingresses/resources.yaml
@@ -1,0 +1,69 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-service
+  namespace: foo
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  ingressClassName: nginx-example
+  rules:
+  - http:
+      paths:
+      - path: /testpath
+        pathType: Prefix
+        backend:
+          service:
+            name: test
+            port:
+              number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+  namespace: foo
+  labels:
+    app: my-app
+spec:
+  type: ClusterIP
+  selector:
+    app: my-app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-default-backend
+  namespace: bar
+spec:
+  defaultBackend:
+    service:
+      name: default-backend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-backend
+  namespace: bar
+spec:
+  type: NodePort
+  selector:
+    app: default-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-default-backend
+  namespace: foobar
+spec:
+  defaultBackend:
+    service:
+      name: default-backend

--- a/internal/controller/executor/validate_aggregatedselection/unused_poddisruptionbudget/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_poddisruptionbudget/cleaner.yaml
@@ -47,7 +47,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
       
         local pdbs= {}

--- a/internal/controller/executor/validate_aggregatedselection/unused_roles/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_roles/cleaner.yaml
@@ -26,7 +26,6 @@ spec:
 
       function evaluate()
         local hs = {}
-        hs.valid = true
         hs.message = ""
 
         -- Contains list of existing roles


### PR DESCRIPTION
An Ingress instance is unused if:

- default backend is either not defined and currently not existing
- none of the referenced services (if any) is currently existing