### PR TITLE
Add Cleaner instance to find unused ServiceAccount instances

### DIFF
--- a/examples/service-accounts/cleaner.yaml
+++ b/examples/service-accounts/cleaner.yaml
@@ -1,0 +1,91 @@
+# This Cleaner instance finds all unused ServiceAccounts instances. All namespaces are considered.
+# A ServiceAccount is unused if:
+# - used by no Pod instance
+# - referenced in no RoleBinding
+# - referenced in no ClusterRoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-service-accounts
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pod
+      group: ""
+      version: v1
+    - kind: ServiceAccounts
+      group: ""
+      version: v1
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: ClusterRoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      function getKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      func addRoleBindingServiceAccounts(roleBinding, usedServiceAccounts)
+        if roleBinding.subjects ~= nil then
+          for _,subject in ipairs(roleBinding.subjects) do
+            if subject.kind == "ServiceAccount" then
+              key = getKey(roleBinding.metadata.namespace, subject.name)
+              usedServiceAccounts[key] = true
+            end
+          end
+        end
+      end
+
+      func addClusterRoleBindingServiceAccounts(clusterRoleBinding, usedServiceAccounts)
+        if clusterRoleBinding.subjects ~= nil then
+          for _,subject in ipairs(clusterRoleBinding.subjects) do
+            if subject.kind == "ServiceAccount" then
+              key = getKey(subject.namespace, subject.name)
+              usedServiceAccounts[key] = true
+            end
+          end
+        end
+      end
+
+      func addPodServiceAccount(pod, usedServiceAccounts)
+        key = getKey(pod.metadata.namespace, pod.spec.serviceAccountName)
+        usedServiceAccounts[key] = true
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.message = ""
+
+        local serviceAccounts = {}
+        local usedServiceAccounts = {}
+        local unusedServiceAccounts = {}
+
+        for _, resource in ipairs(resources) do
+            local kind = resource.kind
+            if kind == "ServiceAccounts" then
+              table.insert(serviceAccounts, resource)
+            elseif kind == "Pod" then
+              addPodServiceAccount(resource, usedServiceAccounts)
+            elseif kind == "RoleBinding" then
+              addRoleBindingServiceAccounts(resource, usedServiceAccounts)
+            elseif kind == "ClusterRoleBinding" then
+              addClusterRoleBindingServiceAccounts(resource, usedServiceAccounts)              
+            end
+        end
+
+        -- walk all existing serviceAccounts and find the unused ones
+        for _,serviceAccount in ipars(serviceAccounts) do
+          key = getKey(serviceAccount.metadata.namespace, serviceAccount.metadata.name)
+          if not in usedServiceAccounts then
+            table.insert(unusedServiceAccounts, serviceAccount)
+          end
+        end
+
+        hs.resources = unusedServiceAccounts
+        return hs
+      end        

--- a/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/cleaner.yaml
@@ -1,0 +1,91 @@
+# This Cleaner instance finds all unused ServiceAccounts instances. All namespaces are considered.
+# A ServiceAccount is unused if:
+# - used by no Pod instance
+# - referenced in no RoleBinding
+# - referenced in no ClusterRoleBinding
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: unused-service-accounts
+spec:
+  schedule: "* 0 * * *"
+  dryRun: false
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pod
+      group: ""
+      version: v1
+    - kind: ServiceAccounts
+      group: ""
+      version: v1
+    - kind: RoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    - kind: ClusterRoleBindings
+      group: "rbac.authorization.k8s.io"
+      version: v1
+    action: Delete
+    aggregatedSelection: |
+      function getKey(namespace, name)
+        return namespace .. ":" .. name
+      end
+
+      func addRoleBindingServiceAccounts(roleBinding, usedServiceAccounts)
+        if roleBinding.subjects ~= nil then
+          for _,subject in ipairs(roleBinding.subjects) do
+            if subject.kind == "ServiceAccount" then
+              key = getKey(roleBinding.metadata.namespace, subject.name)
+              usedServiceAccounts[key] = true
+            end
+          end
+        end
+      end
+
+      func addClusterRoleBindingServiceAccounts(clusterRoleBinding, usedServiceAccounts)
+        if clusterRoleBinding.subjects ~= nil then
+          for _,subject in ipairs(clusterRoleBinding.subjects) do
+            if subject.kind == "ServiceAccount" then
+              key = getKey(subject.namespace, subject.name)
+              usedServiceAccounts[key] = true
+            end
+          end
+        end
+      end
+
+      func addPodServiceAccount(pod, usedServiceAccounts)
+        key = getKey(pod.metadata.namespace, pod.spec.serviceAccountName)
+        usedServiceAccounts[key] = true
+      end
+
+      function evaluate()
+        local hs = {}
+        hs.message = ""
+
+        local serviceAccounts = {}
+        local usedServiceAccounts = {}
+        local unusedServiceAccounts = {}
+
+        for _, resource in ipairs(resources) do
+            local kind = resource.kind
+            if kind == "ServiceAccounts" then
+              table.insert(serviceAccounts, resource)
+            elseif kind == "Pod" then
+              addPodServiceAccount(resource, usedServiceAccounts)
+            elseif kind == "RoleBinding" then
+              addRoleBindingServiceAccounts(resource, usedServiceAccounts)
+            elseif kind == "ClusterRoleBinding" then
+              addClusterRoleBindingServiceAccounts(resource, usedServiceAccounts)              
+            end
+        end
+
+        -- walk all existing serviceAccounts and find the unused ones
+        for _,serviceAccount in ipars(serviceAccounts) do
+          key = getKey(serviceAccount.metadata.namespace, serviceAccount.metadata.name)
+          if not in usedServiceAccounts then
+            table.insert(unusedServiceAccounts, serviceAccount)
+          end
+        end
+
+        hs.resources = unusedServiceAccounts
+        return hs
+      end        

--- a/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/matching.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/matching.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-unused
+  namespace: baz

--- a/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/resource.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/unused_service-accounts/resource.yaml
@@ -1,0 +1,69 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-used-by-pod
+  namespace: bar
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  namespace: bar
+  labels:
+    app: my-application
+spec:
+  serviceAccountName: sa-used-by-pod
+  containers:
+  - name: my-container
+    image: busybox:latest
+    command: ["/bin/sh", "-c", "while true; do echo hello from my-pod; sleep 1; done"]
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "200Mi"
+      limits:
+        cpu: "500m"
+        memory: "1Gi"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-used-by-rolebinding
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: my-role-binding
+  namespace: test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: event-gateway
+subjects:
+- kind: ServiceAccount
+  name: sa-used-by-rolebinding
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-used-by-clusterrolebinding
+  namespace: baz
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:kube-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-dns
+subjects:
+- kind: ServiceAccount
+  name: sa-used-by-clusterrolebinding
+  namespace: baz
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa-unused
+  namespace: baz


### PR DESCRIPTION
A ServiceAccount instance is unused if:
- is used by no Pod instance
- is referenced in no RoleBinding
- is referenced in no ClusterRoleBinding