### PR TITLE
Add GenerationChangedPredicate filter

### DIFF
--- a/internal/controller/cleaner_controller.go
+++ b/internal/controller/cleaner_controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	appsv1alpha1 "gianlucam76/k8s-cleaner/api/v1alpha1"
@@ -166,6 +167,7 @@ func (r *CleanerReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1alpha1.Cleaner{}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: r.ConcurrentReconciles,
 		}).


### PR DESCRIPTION
GenerationChangedPredicate implements a default update predicate function on Generation change.

This predicate will skip update events that have no change in the object's metadata.generation field.
The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
