### PR TITLE
Add Patch

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,6 +21,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps.projectsveltos.io

--- a/internal/controller/cleaner_controller.go
+++ b/internal/controller/cleaner_controller.go
@@ -48,7 +48,7 @@ type CleanerReconciler struct {
 	ConcurrentReconciles int
 }
 
-//+kubebuilder:rbac:groups=apps.projectsveltos.io,resources=cleaners,verbs=get;list;watch
+//+kubebuilder:rbac:groups=apps.projectsveltos.io,resources=cleaners,verbs=get;list;watch;patch
 //+kubebuilder:rbac:groups=apps.projectsveltos.io,resources=cleaners/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=apps.projectsveltos.io,resources=cleaners/finalizers,verbs=update
 //+kubebuilder:rbac:groups="*",resources="*",verbs="*"

--- a/manifest/manifest.yaml
+++ b/manifest/manifest.yaml
@@ -403,6 +403,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - apps.projectsveltos.io


### PR DESCRIPTION
Cleaner controller updates metadata by adding finalizer. So it needs a patch permission as well.

So far all worked because Cleaner controller has `*` on any resource as it needs to be able to either delete or update them.