### PR TITLE
Helm chart:  explicitly add 'resources field' to the values.yaml && add deployment revision history limit

### DIFF
--- a/charts/k8s-cleaner/README.md
+++ b/charts/k8s-cleaner/README.md
@@ -41,11 +41,13 @@ Major Changes to functions are documented with the version affected. **Before up
 | controller.ports[1].name | string | `"healthz"` |  |
 | controller.ports[1].protocol | string | `"TCP"` |  |
 | controller.readinessProbe | object | `{"enabled":true,"httpGet":{"path":"/readyz","port":"healthz","scheme":"HTTP"},"initialDelaySeconds":5,"periodSeconds":10}` | Controller ReadinessProbe |
+| controller.resources | object | `{}` | Resource limits and requests for the controller |
 | controller.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"enabled":true,"runAsNonRoot":true}` | Controller SecurityCOntext |
 | controller.volumeMounts | list | `[]` | Controller VolumeMounts |
 | crds.install | bool | `true` | Install the CustomResourceDefinitions (This also manages the lifecycle of the CRDs for update operations) |
 | crds.keep | bool | `true` | Keep the CustomResourceDefinitions (when the chart is deleted) |
 | fullnameOverride | string | `""` | Full name overwrite |
+| historyLimit | int | `3` | The number of old ReplicaSets to retain for a Deployment (default=10) |
 | imagePullSecrets | list | `[]` | ImagePullSecrets |
 | nameOverride | string | `""` | Partial name overwrite |
 | nodeSelector | object | `{}` | NodeSelector |

--- a/charts/k8s-cleaner/templates/deployment.yaml
+++ b/charts/k8s-cleaner/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "k8s-cleaner.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.historyLimit }}
   selector:
     matchLabels:
       {{- include "k8s-cleaner.selectorLabels" . | nindent 6 }}

--- a/charts/k8s-cleaner/values.yaml
+++ b/charts/k8s-cleaner/values.yaml
@@ -64,14 +64,22 @@ controller:
       scheme: HTTP
     initialDelaySeconds: 5
     periodSeconds: 10
-  # -- Controller VolumeMounts
+  # -- Resource limits and requests for the controller
+  resources: {}
+    # requests:
+    #   cpu: 50m
+    #   memory: 100Mi
+    # limits:
+    #   memory: 100Mi
+# -- Controller VolumeMounts
   volumeMounts: []
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
-
 # -- Amount of replicas
 replicaCount: 1
+# -- The number of old ReplicaSets to retain for a Deployment (default=10)
+historyLimit: 3
 
 # -- ImagePullSecrets
 imagePullSecrets: []


### PR DESCRIPTION
- Adding the resources field explicitly in values makes it easier to know whether or not the qos can be configured from chart.
- On CD tools like Argocd, keeping the revision history at 10 (the default value) can make the user experience not too pleasant. 
so adding the field history limit to the deployment gives the user the option to modify this value easily.