### PR TITLE
When looking for unused ConfigMaps, skip certain namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ __Cleaner__ can also be used to identify unhealthy resources.
 
 k8s-cleaner keeps you in the loop with handy notifications through:
 
-1. <img src="assets/slack_logo.png" alt="Slack" width="30" />  [__Slack__](#slack-notification)
-2. <img src="assets/webex_logo.png" alt="Webex" width="30" />  [__Webex__](#webex-notifications)
-3. <img src="assets/discord_logo.png" alt="Discord" width="30" />  [__Discord__](#discord-notifications)
-3. <img src="assets/teams_logo.svg" alt="Teams" width="30" />  [__Teams__](#teams-notifications)
-4.  [__reports__](#cleaner-report)
+1. <img src="assets/slack_logo.png" alt="Slack" width="30" />  [__Slack__](https://gianlucam76.github.io/k8s-cleaner/notifications/notifications/#slack-notifications-example)
+2. <img src="assets/webex_logo.png" alt="Webex" width="30" />  [__Webex__](https://gianlucam76.github.io/k8s-cleaner/notifications/notifications/#webex-notifications-example)
+3. <img src="assets/discord_logo.png" alt="Discord" width="30" />  [__Discord__](https://gianlucam76.github.io/k8s-cleaner/notifications/notifications/#discord-notifications-example)
+3. <img src="assets/teams_logo.svg" alt="Teams" width="30" />  [__Teams__](https://gianlucam76.github.io/k8s-cleaner/notifications/notifications/#teams-notifications-example)
+4.  [__reports__](https://gianlucam76.github.io/k8s-cleaner/reports/k8s-cleaner_reports/)
   
 Each notification contains list of all resources successfully deleted (or modified) by k8s-cleaner. Choose what works best for you!
 

--- a/docs/getting_started/examples/unused_resources/configmap.md
+++ b/docs/getting_started/examples/unused_resources/configmap.md
@@ -16,7 +16,7 @@ authors:
 
 There are many Kubernetes installations either as a manifest or a Helm chart that after undeployment leave `ConfigMap` behind.
 
-The below Cleaner instance finds all the `ConfigMaps` instances in **all** the namespaces which are **orphaned**.
+The below Cleaner instance finds all the `ConfigMaps` instances in **all** the namespaces which are **orphaned** (namespaces starting with ```kube``` are excluded)
 
 ### Orphaned ConfigMap
 
@@ -46,6 +46,10 @@ By orphaned we refer to a ConfigMap that is not used by:
 		  group: ""
 		  version: v1   
 		aggregatedSelection: |
+          function skipNamespace(namespace)
+            return string.match(namespace, '^kube')
+          end
+
 		  function getKey(namespace, name)
 			return namespace .. ":" .. name
 		  end 
@@ -134,7 +138,7 @@ By orphaned we refer to a ConfigMap that is not used by:
 			-- Separate configMaps and podsfrom the resources
 			for _, resource in ipairs(resources) do
 				local kind = resource.kind
-				if kind == "ConfigMap" then
+				if kind == "ConfigMap" and not skipNamespace(resource.metadata.namespace) then
 				  table.insert(configMaps, resource)
 				elseif kind == "Pod" then
 				  table.insert(pods, resource)

--- a/examples-unused-resources/configmaps/orphaned_configmaps.yaml
+++ b/examples-unused-resources/configmaps/orphaned_configmaps.yaml
@@ -18,6 +18,10 @@ spec:
       group: ""
       version: v1   
     aggregatedSelection: |
+      function skipNamespace(namespace)
+        return string.match(namespace, '^kube')
+      end
+
       function getKey(namespace, name)
         return namespace .. ":" .. name
       end 
@@ -106,7 +110,7 @@ spec:
         -- Separate configMaps and podsfrom the resources
         for _, resource in ipairs(resources) do
             local kind = resource.kind
-            if kind == "ConfigMap" then
+            if kind == "ConfigMap" and not skipNamespace(resource.metadata.namespace) then
               table.insert(configMaps, resource)
             elseif kind == "Pod" then
               table.insert(pods, resource)

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/cleaner.yaml
@@ -18,6 +18,10 @@ spec:
       group: ""
       version: v1   
     aggregatedSelection: |
+      function skipNamespace(namespace)
+        return string.match(namespace, '^kube')
+      end
+
       function getKey(namespace, name)
         return namespace .. ":" .. name
       end 
@@ -106,7 +110,7 @@ spec:
         -- Separate configMaps and podsfrom the resources
         for _, resource in ipairs(resources) do
             local kind = resource.kind
-            if kind == "ConfigMap" then
+            if kind == "ConfigMap" and not skipNamespace(resource.metadata.namespace) then
               table.insert(configMaps, resource)
             elseif kind == "Pod" then
               table.insert(pods, resource)

--- a/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/resources.yaml
+++ b/internal/controller/executor/validate_aggregatedselection/orphaned_configmaps/resources.yaml
@@ -89,3 +89,12 @@ metadata:
 data:
   SPECIAL_LEVEL: very
   SPECIAL_TYPE: charm
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: not-matching
+  namespace: kube-system
+data:
+  SPECIAL_LEVEL: very
+  SPECIAL_TYPE: charm


### PR DESCRIPTION
Namespaces starting with ```kube``` are ignored