### PR TITLE
Notification types

### DIFF
--- a/api/v1alpha1/cleaner_types.go
+++ b/api/v1alpha1/cleaner_types.go
@@ -112,6 +112,9 @@ const (
 
 	// NotificationTypeTeams refers to generating a Teams message
 	NotificationTypeTeams = NotificationType("Teams")
+
+	// NotificationTypeSMTP refers to sending an email
+	NotificationTypeSMTP = NotificationType("SMTP")
 )
 
 type Notification struct {

--- a/internal/controller/executor/notifications.go
+++ b/internal/controller/executor/notifications.go
@@ -79,26 +79,22 @@ func sendNotifications(ctx context.Context, resources []ResourceResult,
 
 		var err error
 
-		// temporary conditional while implementing smtp notifications
-		// type mismatch in the switch statement prevents this from being a case
-		if string(notification.Type) == string(libsveltosv1beta1.NotificationTypeSMTP) {
+		switch notification.Type {
+		case appsv1alpha1.NotificationTypeCleanerReport:
+			err = createReportInstance(ctx, cleaner, reportSpec, logger)
+		case appsv1alpha1.NotificationTypeSlack:
+			err = sendSlackNotification(ctx, reportSpec, message, notification, logger)
+		case appsv1alpha1.NotificationTypeWebex:
+			err = sendWebexNotification(ctx, reportSpec, message, notification, logger)
+		case appsv1alpha1.NotificationTypeDiscord:
+			err = sendDiscordNotification(ctx, reportSpec, message, notification, logger)
+		case appsv1alpha1.NotificationTypeTeams:
+			err = sendTeamsNotification(ctx, reportSpec, message, notification, logger)
+		case appsv1alpha1.NotificationTypeSMTP:
 			err = sendSmtpNotification(ctx, reportSpec, message, notification, logger)
-		} else {
-			switch notification.Type {
-			case appsv1alpha1.NotificationTypeCleanerReport:
-				err = createReportInstance(ctx, cleaner, reportSpec, logger)
-			case appsv1alpha1.NotificationTypeSlack:
-				err = sendSlackNotification(ctx, reportSpec, message, notification, logger)
-			case appsv1alpha1.NotificationTypeWebex:
-				err = sendWebexNotification(ctx, reportSpec, message, notification, logger)
-			case appsv1alpha1.NotificationTypeDiscord:
-				err = sendDiscordNotification(ctx, reportSpec, message, notification, logger)
-			case appsv1alpha1.NotificationTypeTeams:
-				err = sendTeamsNotification(ctx, reportSpec, message, notification, logger)
-			default:
-				logger.V(logs.LogInfo).Info("no handler registered for notification")
-				panic(1)
-			}
+		default:
+			logger.V(logs.LogInfo).Info("no handler registered for notification")
+			panic(1)
 		}
 
 		if err != nil {


### PR DESCRIPTION
Sveltos and k8s-cleaner shares some notification types (Slack, Webex, Discord, Teams and soon SMTP). But other notifications types are different (Reports and soon Telegram).

I feel the right approach is to:

1. have common logic in libsveltos but
2. have different Notification Types

This will allow logic which is common to be be moved to libsveltos while yet allowing different notification types to be supported.