### PR TITLE
Add evicted pods example configuration

### DIFF
--- a/examples-unhealthy-resources/pod-with-evicted-state/pod-with-evicted-state.yml
+++ b/examples-unhealthy-resources/pod-with-evicted-state/pod-with-evicted-state.yml
@@ -1,0 +1,26 @@
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: evicted-pods
+spec:
+  schedule: "*/5 * * * *"
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pod
+      group: ""
+      version: v1
+      excludeDeleted: false
+      evaluate: |
+        function evaluate()
+          hs = {}
+          hs.matching = false
+
+          -- Check if the pod's status is Failed and the reason is Evicted
+          if obj.status.phase == "Failed" and obj.status.reason == "Evicted" then
+            -- If the pod is evicted, mark it for cleaning
+            hs.matching = true
+          end
+
+          return hs
+        end
+  action: Delete

--- a/examples-unhealthy-resources/pod-with-evicted-state/pod-with-evicted-state.yml
+++ b/examples-unhealthy-resources/pod-with-evicted-state/pod-with-evicted-state.yml
@@ -1,3 +1,9 @@
+# This Cleaner instance is designed to find all evicted Pod instances in all namespaces.
+# It evaluates pods that have failed with the reason "Evicted" and marks them for deletion.
+# The cleaner runs on a scheduled interval every 5 minutes, ensuring that evicted pods
+# are promptly removed, freeing up cluster resources and maintaining a clean environment.
+# By automatically deleting evicted pods, this Cleaner helps improve resource management
+# and cluster performance.
 apiVersion: apps.projectsveltos.io/v1alpha1
 kind: Cleaner
 metadata:


### PR DESCRIPTION
This PR addresses the issue of evicted pods that remain on the Kubernetes cluster after being created. Over time, these evicted pods can accumulate, leading to resource wastage and clutter in the cluster.

The proposed solution is to introduce a configuration file that schedules the deletion of evicted pods every 5 minutes across the cluster. This will ensure that any evicted pods are cleaned up promptly, improving cluster hygiene and freeing up resources.