### PR TITLE
Add topolgySpreadConstraints support to helm

### DIFF
--- a/charts/k8s-cleaner/README.md
+++ b/charts/k8s-cleaner/README.md
@@ -72,4 +72,5 @@ Major Changes to functions are documented with the version affected. **Before up
 | serviceMonitor.namespace | string | `""` | Install the ServiceMonitor into a different Namespace, as the monitoring stack one (default: the release one) |
 | serviceMonitor.targetLabels | list | `[]` | Set targetLabels for the serviceMonitor |
 | tolerations | list | `[]` | Tolerations |
+| topologySpreadConstraints | object | `{}` | TopolySpreadConstrains |
 | volumes | list | `[]` | Additional volumes on the output Deployment definition. |

--- a/charts/k8s-cleaner/templates/deployment.yaml
+++ b/charts/k8s-cleaner/templates/deployment.yaml
@@ -90,6 +90,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/k8s-cleaner/values.yaml
+++ b/charts/k8s-cleaner/values.yaml
@@ -113,6 +113,9 @@ tolerations: []
 # -- Affinity
 affinity: {}
 
+# -- TopolySpreadConstrains
+topologySpreadConstraints: {}
+
 serviceAccount:
   # -- Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
# Add topologySpreadConstraints to Helm Charts

This PR introduces `topologySpreadConstraints` to the Helm charts to improve availability and fault tolerance in multi-zone Kubernetes clusters. The changes ensure that pod replicas are evenly distributed across zones using the topology.kubernetes.io/zone label, minimizing the risk of zone-specific failures.

## Key Changes:
**Topology Spread Constraints**: Evenly distributes replicas across zones with a configurable maxSkew.
These changes are optional and configurable via `values.yaml`, providing better fault isolation without breaking existing deployments.