### PR TITLE
[Helm chart] Prometheus scraping failed

### DIFF
--- a/charts/k8s-cleaner/README.md
+++ b/charts/k8s-cleaner/README.md
@@ -67,6 +67,7 @@ Major Changes to functions are documented with the version affected. **Before up
 | serviceMonitor.endpoint.metricRelabelings | list | `[]` | Set metricRelabelings for the endpoint of the serviceMonitor |
 | serviceMonitor.endpoint.relabelings | list | `[]` | Set relabelings for the endpoint of the serviceMonitor |
 | serviceMonitor.endpoint.scrapeTimeout | string | `""` | Set the scrape timeout for the endpoint of the serviceMonitor |
+| serviceMonitor.endpoint.tlsConfig | object | `{"insecureSkipVerify":true}` | Set TLSConfig for the endpoint of the serviceMonitor |
 | serviceMonitor.jobLabel | string | `"app.kubernetes.io/name"` | Set JobLabel for the serviceMonitor |
 | serviceMonitor.labels | object | `{}` | Assign additional labels according to Prometheus' serviceMonitorSelector matching labels |
 | serviceMonitor.matchLabels | object | `{}` | Change matching labels |

--- a/charts/k8s-cleaner/templates/servicemonitor.yaml
+++ b/charts/k8s-cleaner/templates/servicemonitor.yaml
@@ -19,6 +19,12 @@ spec:
   - interval: {{ .interval }}
     port: metrics
     path: /metrics
+    scheme: https
+    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    {{- with .tlsConfig }}
+    tlsConfig:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .scrapeTimeout }}
     scrapeTimeout: {{ . }}
     {{- end }}

--- a/charts/k8s-cleaner/values.yaml
+++ b/charts/k8s-cleaner/values.yaml
@@ -152,6 +152,9 @@ serviceMonitor:
     metricRelabelings: []
     # -- Set relabelings for the endpoint of the serviceMonitor
     relabelings: []
+    # -- Set TLSConfig for the endpoint of the serviceMonitor
+    tlsConfig:
+      insecureSkipVerify: true
 
 # -- Extra Kubernetes objects to deploy with the helm chart
 extraObjects: []


### PR DESCRIPTION
ServiceMonitor created using Helm chart appears in error in prometheus with message "server returned HTTP status 400 Bad Request"

The reason is that the metrics port in k8s-cleaner pod is on https scheme (port 8443 not configurable) but the servicemonitor object comes with no scheme which means http.

Futhermore, a curl on the metrics port respond by a "401 Unauthorized" error, meaning that it needs a token to access the page.

Based on [config/prometheus/monitor.yaml](https://github.com/gianlucam76/k8s-cleaner/blob/main/config/prometheus/monitor.yaml), this PR adds scheme and bearerTokenFile to servicemonitors endpoint and offers the ability to customize tlsOptions.
