### PR TITLE
(bug) Description: Clarify CleanerReport requirement for Web Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ There are also examples to identify unhealthy resources:
 
 5️⃣ [**Notifications**](https://gianlucam76.github.io/k8s-cleaner/notifications/notifications/): Stay informed! The k8s-cleaner keeps users in the loop about every cleaned-up resource, whether removed or optimized. Get detailed notification lists and pick your preferred channel: Slack, Webex, Discord, Teams, Telegram, SMTP or reports.
 
-6️⃣ [**Web Dashboard**](https://gianlucam76.github.io/k8s-cleaner/getting_started/install/install#web-dashboard): Visualize your cluster's health! Use the optional embedded dashboard to browse scan results via a responsive UI, inspect your Lua scripts, and trigger on-demand cleanup tasks with a single click. It can be easily enabled via Helm and supports both dark mode and read-only configurations.
+6️⃣ [**Web Dashboard**](https://gianlucam76.github.io/k8s-cleaner/docs/getting_started/install/install#web-dashboard): Visualize your cluster's health! Use the optional embedded dashboard to browse scan results via a responsive UI, inspect your Lua scripts, and trigger on-demand cleanup tasks with a single click. It can be easily enabled via Helm and supports both dark mode and read-only configurations.
 
 For a complete list of **features** with **examples**, have a look at the [link](https://gianlucam76.github.io/k8s-cleaner/getting_started/features/dryrun/dryrun/).
 

--- a/docs/getting_started/install/install.md
+++ b/docs/getting_started/install/install.md
@@ -96,6 +96,22 @@ The k8s-cleaner includes an optional **embedded web dashboard** that provides a 
 4. **Report Browser**: Filterable scan reports with status bar charts to track resource improvements over time.
 5. **Flexible Access**: Supports dark/light modes, responsive mobile layouts, and an optional Read-Only mode for production environments.
 
+**⚠️ Important: Data Requirements**
+
+The dashboard does not "poll" the cluster directly for matches; instead, it visualizes CleanerReport objects. For a Cleaner instance to appear in the dashboard, you must configure it to generate a report via the notifications field.
+
+Without this configuration, the dashboard will remain empty even if the Cleaner is active.
+
+Add the following to your Cleaner custom resources to enable reporting:
+
+```yaml
+spec:
+  # ... other cleaner settings ...
+  notifications:
+    - name: report
+      type: CleanerReport
+```
+
 #### Enabling the Dashboard via Helm
 
 The dashboard is disabled by default. To enable it during installation, set the web.enabled value to true.


### PR DESCRIPTION
This PR updates the Web Dashboard documentation to clarify a critical requirement: the dashboard relies on CleanerReport objects to display data. Currently, users may enable the dashboard via Helm but find it empty because their Cleaner instances are not configured to generate reports.

Fixes #579 