### PR TITLE
(bug) fix metric names

### DIFF
--- a/internal/controller/executor/export_test.go
+++ b/internal/controller/executor/export_test.go
@@ -36,6 +36,18 @@ var (
 	GetSlackInfo = getSlackInfo
 )
 
+var (
+	GetDeletedResourcesCounterVec = getDeletedResourcesCounterVec
+	GetUpdatedResourcesCounterVec = getUpdatedResourcesCounterVec
+	GetScanResourcesCounterVec    = getScanResourcesCounterVec
+	GetErrorResourcesCounterVec   = getErrorResourcesCounterVec
+
+	GetDeletedResourcesGaugeVec = getDeletedResourcesGaugeVec
+	GetUpdatedResourcesGaugeVec = getUpdatedResourcesGaugeVec
+	GetScanResourcesGaugeVec    = getScanResourcesGaugeVec
+	GetErrorResourcesGaugeVec   = getErrorResourcesGaugeVec
+)
+
 func (m *Manager) ClearInternalStruct() {
 	m.dirty = make([]string, 0)
 	m.inProgress = make([]string, 0)

--- a/internal/controller/executor/metrics.go
+++ b/internal/controller/executor/metrics.go
@@ -17,8 +17,6 @@ limitations under the License.
 package executor
 
 import (
-	"os"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
@@ -56,8 +54,7 @@ const (
 var (
 	deletedResourceCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      deletedCounterName,
+				Name:      deletedCounterName,
 			Help:      deletedCounterHelp,
 		},
 		[]string{"cleaner_instance", "resource_apiversion", "resource_type"},
@@ -65,8 +62,7 @@ var (
 
 	updatedResourceCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      updatedCounterName,
+				Name:      updatedCounterName,
 			Help:      updatedCounterHelp,
 		},
 		[]string{"cleaner_instance", "resource_apiversion", "resource_type"},
@@ -74,8 +70,7 @@ var (
 
 	scanResourceCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      scanCounterName,
+				Name:      scanCounterName,
 			Help:      scanCounterHelp,
 		},
 		[]string{"cleaner_instance", "resource_apiversion", "resource_type"},
@@ -83,8 +78,7 @@ var (
 
 	errorResourceCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      errorCounterName,
+				Name:      errorCounterName,
 			Help:      errorCounterHelp,
 		},
 		[]string{"cleaner_instance", "resource_apiversion", "resource_type"},
@@ -95,8 +89,7 @@ var (
 	// New Gauge Definitions
 	deletedResourceGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      deletedGaugeName,
+				Name:      deletedGaugeName,
 			Help:      deletedGaugeHelp,
 		},
 		[]string{"cleaner_instance"},
@@ -104,8 +97,7 @@ var (
 
 	updatedResourceGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      updatedGaugeName,
+				Name:      updatedGaugeName,
 			Help:      updatedGaugeHelp,
 		},
 		[]string{"cleaner_instance"},
@@ -113,8 +105,7 @@ var (
 
 	scanResourceGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      scanGaugeName,
+				Name:      scanGaugeName,
 			Help:      scanGaugeHelp,
 		},
 		[]string{"cleaner_instance"},
@@ -122,8 +113,7 @@ var (
 
 	errorResourceGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Namespace: os.Getenv("NAMESPACE"),
-			Name:      errorGaugeName,
+				Name:      errorGaugeName,
 			Help:      errorGaugeHelp,
 		},
 		[]string{"cleaner_instance"},
@@ -155,7 +145,7 @@ func reportDeletionEvent(cleanerName, resourceAPIVersion, resourceKind string) {
 
 // getUpdatedResourcesCounterVec returns the singleton CounterVec instance.
 func getUpdatedResourcesCounterVec() *prometheus.CounterVec {
-	return deletedResourceCounter
+	return updatedResourceCounter
 }
 
 func reportUpdateEvent(cleanerName, resourceAPIVersion, resourceKind string) {

--- a/internal/controller/executor/metrics_test.go
+++ b/internal/controller/executor/metrics_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2025. projectsveltos.io. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+
+	"gianlucam76/k8s-cleaner/internal/controller/executor"
+)
+
+// descFQName extracts the fully-qualified metric name from a collector's descriptor.
+func descFQName(col prometheus.Collector) string {
+	ch := make(chan *prometheus.Desc, 1)
+	col.Describe(ch)
+	return (<-ch).String()
+}
+
+var _ = Describe("metrics", func() {
+	It("each counter vec getter returns its own distinct instance", func() {
+		deleted := executor.GetDeletedResourcesCounterVec()
+		updated := executor.GetUpdatedResourcesCounterVec()
+		scan := executor.GetScanResourcesCounterVec()
+		errVec := executor.GetErrorResourcesCounterVec()
+
+		Expect(updated).ToNot(BeIdenticalTo(deleted))
+		Expect(scan).ToNot(BeIdenticalTo(deleted))
+		Expect(errVec).ToNot(BeIdenticalTo(deleted))
+	})
+
+	DescribeTable("metric names do not include a namespace prefix",
+		func(col prometheus.Collector, expectedName string) {
+			desc := descFQName(col)
+			Expect(desc).To(ContainSubstring(fmt.Sprintf(`fqName: %q`, expectedName)))
+		},
+		Entry("deleted counter", executor.GetDeletedResourcesCounterVec(), "k8s_cleaner_deleted_resources_total"),
+		Entry("updated counter", executor.GetUpdatedResourcesCounterVec(), "k8s_cleaner_updated_resources_total"),
+		Entry("scan counter", executor.GetScanResourcesCounterVec(), "k8s_cleaner_scan_resources_total"),
+		Entry("error counter", executor.GetErrorResourcesCounterVec(), "k8s_cleaner_error_resources_total"),
+		Entry("deleted gauge", executor.GetDeletedResourcesGaugeVec(), "k8s_cleaner_current_deleted_resources_count"),
+		Entry("updated gauge", executor.GetUpdatedResourcesGaugeVec(), "k8s_cleaner_current_updated_resources_count"),
+		Entry("scan gauge", executor.GetScanResourcesGaugeVec(), "k8s_cleaner_current_resources_count"),
+		Entry("error gauge", executor.GetErrorResourcesGaugeVec(), "k8s_cleaner_current_error_resources_count"),
+	)
+})


### PR DESCRIPTION
Prometheus metrics were incorrectly prefixed with deployment namespace. This PR fixes that.

Fixes #538 