### PR TITLE
ci: add workflow_dispatch to documentation workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: ci
 on:
+  workflow_dispatch:
   push:
     branches:
     - main


### PR DESCRIPTION
Adds `workflow_dispatch` trigger to the `ci.yml` documentation workflow so it can be manually triggered from the GitHub Actions UI.

This is needed to bootstrap the first deployment.
The workflow configures GitHub Pages to use "GitHub Actions" as the source and deploys the MkDocs site.
After the first run, docs will automatically redeploy whenever a PR merging into main contains changes under `docs/**`.