### PR TITLE
docs(resourceselector): Document namespace selection and exclusion

### DIFF
--- a/docs/getting_started/features/resourceselector/resourceselector.md
+++ b/docs/getting_started/features/resourceselector/resourceselector.md
@@ -86,3 +86,107 @@ spec:
         return hs
       end
 ```
+
+## Selecting Namespaces
+
+Each entry in the `resourceSelectors` list can limit the namespaces it looks at. Two fields control this.
+
+| Field | Description |
+|---|---|
+| `namespace` | A single namespace, by name. |
+| `namespaceSelector` | A Kubernetes label selector. Every namespace in the cluster whose labels match is considered. |
+
+If **both** are set, the two results are combined: the Cleaner considers the namespaces matched by `namespaceSelector` **plus** the one named in `namespace`.
+
+If **neither** is set, the Cleaner considers resources in **all** namespaces.
+
+### A Single Namespace
+
+Restrict the Cleaner to the `foo` namespace.
+
+```yaml
+resourceSelectors:
+- namespace: foo
+  kind: Pod
+  group: ""
+  version: v1
+```
+
+### Namespaces by Label
+
+`namespaceSelector` accepts any valid Kubernetes label selector. To act only on namespaces labelled `environment=dev`:
+
+```yaml
+resourceSelectors:
+- namespaceSelector: "environment=dev"
+  kind: Pod
+  group: ""
+  version: v1
+```
+
+## Excluding Namespaces
+
+A common requirement is the inverse: run a Cleaner across the whole cluster, but never touch protected namespaces such as `kube-system`. This is worth stating explicitly, because it is easy to assume a dedicated "exclude" field is needed. It is not.
+
+`namespaceSelector` is parsed as a full Kubernetes label selector, so it supports **set-based operators**, including `notin`. Kubernetes also labels every namespace automatically with `kubernetes.io/metadata.name`, whose value is the namespace's own name. No manual labelling is required.
+
+Put those together and you can exclude namespaces **by name**:
+
+```yaml
+namespaceSelector: "kubernetes.io/metadata.name notin (kube-system,cattle-system,cert-manager)"
+```
+
+### Example - Delete Failed Pods, Except in Protected Namespaces
+
+This Cleaner deletes Pods that terminated with an error, in every namespace except the protected ones. Note that the `evaluate` function contains no namespace check at all: the namespace filtering happens in `namespaceSelector`, which keeps the exclusion list declarative and in one place.
+
+```yaml
+---
+apiVersion: apps.projectsveltos.io/v1alpha1
+kind: Cleaner
+metadata:
+  name: error-state-pods
+spec:
+  schedule: "0 * * * *"
+  action: Delete
+  resourcePolicySet:
+    resourceSelectors:
+    - kind: Pod
+      group: ""
+      version: v1
+      namespaceSelector: "kubernetes.io/metadata.name notin (kube-system,cattle-system,cert-manager,my-production-db)"
+      evaluate: |
+        function evaluate()
+          hs = {}
+          hs.matching = false
+          if obj.status.phase == "Failed" then
+            if obj.status.containerStatuses then
+              for _, containerStatus in ipairs(obj.status.containerStatuses) do
+                if containerStatus.state and containerStatus.state.terminated and
+                   containerStatus.state.terminated.reason == "Error" and
+                   containerStatus.state.terminated.exitCode ~= 0 then
+                  hs.matching = true
+                  break
+                end
+              end
+            end
+          end
+          return hs
+        end
+```
+
+!!! warning "Make sure the selector matches at least one namespace"
+    A `namespaceSelector` that matches **no** namespace does not narrow the Cleaner down to nothing. The Cleaner falls back to considering **all** namespaces, exactly as if no namespace filtering had been set.
+
+    This matters most when `action` is `Delete`. Before applying an exclusion selector, confirm it selects the namespaces you expect:
+
+    ```bash
+    kubectl get namespaces -l 'kubernetes.io/metadata.name notin (kube-system,cattle-system,cert-manager)'
+    ```
+
+    Running the Cleaner in [dry-run mode](../dryrun/dryrun.md) first is the safest way to review what it would act on.
+
+!!! note "Things to keep in mind"
+    - `namespaceSelector` is set **per `resourceSelector`**. A Cleaner that selects several kinds must repeat the selector on each entry.
+    - The automatic `kubernetes.io/metadata.name` label is applied by Kubernetes from **v1.22** onwards. On older clusters, label the namespaces yourself and select on your own label.
+    - Namespace selection does not apply to **cluster-scoped** resources, which do not belong to a namespace.


### PR DESCRIPTION
Closes #373.

In #373 I asked for an `excludedNamespaces` field. @gianlucam76 replied that this is already possible, and he is right — but there is a third route that is nicer than either option in that thread, and none of it is documented.

## The capability already exists

`namespaceSelector` is declared as a plain string (`api/v1alpha1/cleaner_types.go:110`) and parsed with `labels.Parse()` (`internal/controller/executor/worker.go:501`). That is the full apimachinery selector parser, so it accepts **set-based operators**, including `notin`. Kubernetes separately labels every namespace with `kubernetes.io/metadata.name` (the `NamespaceDefaultLabelName` admission plugin, default since v1.22).

Put together, namespaces can be excluded **by name** today, with no new API field and no manual labelling:

```yaml
namespaceSelector: "kubernetes.io/metadata.name notin (kube-system,cattle-system,cert-manager)"
```

This is more declarative than an ignore-list inside the Lua `evaluate`, and needs no pre-labelling of namespaces.

## But it is undiscoverable

- `namespaceSelector` appears **zero times** in `docs/`.
- `kubernetes.io/metadata.name` appears **zero times** in the repository.
- The "Resource Selection" page is about `aggregatedSelection` and never documents `namespace` or `namespaceSelector`.

So this PR is documentation only — no code, no API change.

## What this adds

A purely additive change to `docs/getting_started/features/resourceselector/resourceselector.md`. Nothing existing is moved or reworded:

- **Selecting Namespaces** — the `namespace` and `namespaceSelector` fields, how they combine, and what happens when neither is set. Single-namespace and label-based selection.
- **Excluding Namespaces** — the `notin` idiom, plus the failed-pods example from #373 with the namespace check removed from the Lua.
- A warning admonition and a caveats note (per-`resourceSelector`; requires k8s >= 1.22; not applicable to cluster-scoped kinds).

Both new sections land in the page ToC and search index, so no nav change was needed.

## Verification

Docs build clean with the project toolchain (`zensical build` → `No issues found`), and every snippet in the new text was executed on a kind cluster (Kubernetes v1.36.1) running k8s-cleaner from `manifest/manifest.yaml`.

Four **identically failed** pods (`Failed` / `Error` / exit 1, so all matching the Lua) were created in `kube-system`, `cert-manager`, `my-app` and `default`, then the documented Cleaner was applied. Controller log:

```
getMatchingResources: found a match  resource="Pod:my-app/failer"
getMatchingResources: found a match  resource="Pod:default/failer"
deleting resource                    resource="Pod:my-app/failer"
deleting resource                    resource="Pod:default/failer"
```

The two protected pods were never even considered as candidates — `namespaceSelector` filtered them out at collection time, before the Lua ran. They survived; the other two were deleted.

## One thing worth your call, @gianlucam76

While verifying, I hit this in `internal/controller/executor/worker.go:422`:

```go
if len(namespaces) > 0 {
    result, err = collectFromNamespaces(ctx, config, namespaces, &resourceId, &options)
} else {
    result, err = collectWithOptions(ctx, config, &resourceId, &options)   // all namespaces
}
```

A `namespaceSelector` that matches **zero** namespaces does not narrow the Cleaner to nothing — it falls back to scanning **every** namespace. With `action: Delete`, a typo in an exclusion selector could therefore widen its blast radius rather than shrink it.

I have **not** treated this as a bug in the docs. The warning box states it neutrally as behaviour and gives users a `kubectl` command to check their selector first. Whether the fail-open default itself should change is your call — happy to open a separate issue if you would like.