### PR TITLE
fix(chart): Support custom deployment controller ports

### DIFF
--- a/charts/k8s-cleaner/templates/_helpers.tpl
+++ b/charts/k8s-cleaner/templates/_helpers.tpl
@@ -61,6 +61,19 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Resolve a controller port by name, falling back to a default value when absent.
+*/}}
+{{- define "k8s-cleaner.portByName" -}}
+{{- $ports := .ports | default (list) -}}
+{{- $port := .default | default 0 -}}
+{{- range $ports }}
+{{- if eq .name $.name }}
+{{- $port = .containerPort -}}
+{{- end }}
+{{- end }}
+{{- printf "%v" $port -}}
+{{- end }}
 
 {{- define "k8s-cleaner.template" -}}
   {{- if $.ctx }}

--- a/charts/k8s-cleaner/templates/deployment.yaml
+++ b/charts/k8s-cleaner/templates/deployment.yaml
@@ -42,7 +42,8 @@ spec:
           image: "{{ .Values.controller.image.registry | trimSuffix "/" }}/{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
-          - "--diagnostics-address=:8443"
+          - "--diagnostics-address=:{{ include "k8s-cleaner.portByName" (dict "ports" .Values.controller.ports "name" "metrics" "default" 8443) }}"
+          - "--health-addr=:{{ include "k8s-cleaner.portByName" (dict "ports" .Values.controller.ports "name" "healthz" "default" 9440) }}"
           - "--version={{ .Chart.AppVersion }}"
         {{- if .Values.web.enabled }}
           - "--enable-web"
@@ -74,12 +75,19 @@ spec:
           command:
           - /manager
           ports:
-            - containerPort: 8443
+            - containerPort: {{ include "k8s-cleaner.portByName" (dict "ports" .Values.controller.ports "name" "metrics" "default" 8443) }}
               name: metrics
               protocol: TCP
-            - containerPort: 9440
+            - containerPort: {{ include "k8s-cleaner.portByName" (dict "ports" .Values.controller.ports "name" "healthz" "default" 9440) }}
               name: healthz
               protocol: TCP
+          {{- range .Values.controller.ports }}
+          {{- if and (ne .name "metrics") (ne .name "healthz") }}
+            - containerPort: {{ .containerPort }}
+              name: {{ .name }}
+              protocol: {{ .protocol }}
+          {{- end }}
+          {{- end }}
           {{- if .Values.web.enabled }}
             - containerPort: {{ .Values.web.port }}
               name: web


### PR DESCRIPTION
This PR for helm-chart.

Avoid using hardcoded ports in the deployment controller:
https://github.com/gianlucam76/k8s-cleaner/blob/fcc2273421a7249dc12014f4f87af8669470e507/charts/k8s-cleaner/templates/deployment.yaml#L76-L82

And add the health address option in the deployment template:
https://github.com/gianlucam76/k8s-cleaner/blob/fcc2273421a7249dc12014f4f87af8669470e507/cmd/main.go#L221-L222

So, both can support custom value ports.

Fix issue: [BUG: The port controller cannot support custom in the helm chart](https://github.com/gianlucam76/k8s-cleaner/issues/669)